### PR TITLE
feat: arrange KPI layout by aspect ratio

### DIFF
--- a/CircularKPI.js
+++ b/CircularKPI.js
@@ -1,5 +1,5 @@
 /*globals define*/
-define(["jquery", "text!./scripts/style.css", "./scripts/themes", "./scripts/d3.min", "./scripts/radialProgress"], function($, cssContent, chart_theme) {
+define(["jquery", "text!./scripts/style.css", "./scripts/themes", "./scripts/d3.min", "./scripts/radialProgress"], function ($, cssContent, chart_theme) {
     'use strict';
     $("<style>").html(cssContent).appendTo("head");
     return {
@@ -51,24 +51,24 @@ define(["jquery", "text!./scripts/style.css", "./scripts/themes", "./scripts/d3.
                                     ref: "animationtime",
                                     defaultValue: 1000
                                 },
-								singlekpilabel: {
-									type: "string",
-									label: "Single KPI Label",
-									ref: "singlekpilabel",
-									defaultValue: ""
-								},
-								showdecimals: {
-									type: "boolean",
-									label: "Show decimal values",
-									ref: "showdecimals",
-									defaultValue: false
-								},
-								showpercentage: {
-									type: "boolean",
-									label: "Show percent (%) symbol",
-									ref: "showpercentage",
-									defaultValue: true
-								}
+                                singlekpilabel: {
+                                    type: "string",
+                                    label: "Single KPI Label",
+                                    ref: "singlekpilabel",
+                                    defaultValue: ""
+                                },
+                                showdecimals: {
+                                    type: "boolean",
+                                    label: "Show decimal values",
+                                    ref: "showdecimals",
+                                    defaultValue: false
+                                },
+                                showpercentage: {
+                                    type: "boolean",
+                                    label: "Show percent (%) symbol",
+                                    ref: "showpercentage",
+                                    defaultValue: true
+                                }
                             }
                         }
                     }
@@ -78,41 +78,59 @@ define(["jquery", "text!./scripts/style.css", "./scripts/themes", "./scripts/d3.
         snapshot: {
             canTakeSnapshot: true
         },
-        paint: function($element, layout) {
+        paint: function ($element, layout) {
 
             $element.empty();
-			
-			var id = "container_" + layout.qInfo.qId;
-			var width = $element.width();
-			var height = $element.height();
-			if(document.getElementById(id)) {
-				$("#" + id).empty();
-			}
-			else {
-				$element.append($('<div />').attr("id", id).attr("class", "viz").width(width).height(height));
-			}
+
+            var id = "container_" + layout.qInfo.qId;
+            var width = $element.width();
+            var height = $element.height();
+            if (document.getElementById(id)) {
+                $("#" + id).empty();
+            }
+            else {
+                $element.append($('<div />').attr("id", id).attr("class", "viz").width(width).height(height));
+            }
 
             var IS_SPARK_LAYOUT = this.options.layoutMode === 1;
             var HAS_DIMENSION = layout.qHyperCube.qDimensionInfo.length > 0;
-			var HAS_TWO_DIMENSION = layout.qHyperCube.qDimensionInfo.length > 1;
+            var HAS_TWO_DIMENSION = layout.qHyperCube.qDimensionInfo.length > 1;
 
             var data = layout.qHyperCube.qDataPages[0].qMatrix;
             var label = layout.qHyperCube.qMeasureInfo[0].qFallbackTitle;
 
             var colors = [layout.theme[0], layout.theme[1], layout.theme[2]];
             var animationTime = layout.animationtime;
-			var showdecimals = layout.showdecimals;
-			var showpercentage = layout.showpercentage;
+            var showdecimals = layout.showdecimals;
+            var showpercentage = layout.showpercentage;
 
 
             var rows, columns;
-            if (height > width) {
-                columns = Math.ceil(Math.sqrt(data.length));
-                rows = Math.ceil(data.length / columns);
+
+            // Updated to respect aspect ration
+            var aspectRatio = width / height;
+            var tileGap = 12; // px of white space between KPIs
+
+            if (aspectRatio > 1.5) {
+                // Wide layout: allocate more columns proportionally
+                columns = Math.ceil(Math.sqrt(data.length * aspectRatio));
+            } else if (aspectRatio < 0.75) {
+                // Tall layout: fewer columns
+                columns = Math.ceil(Math.sqrt(data.length / aspectRatio));
             } else {
-                columns = Math.ceil(Math.sqrt(1.5 * data.length) / 1.5);
-                rows = Math.ceil(data.length / columns);
-            };
+                // Balanced layout: near-square
+                columns = Math.ceil(Math.sqrt(data.length));
+            }
+
+            // Safety guards
+            columns = Math.min(columns, data.length);
+            columns = Math.max(columns, 1);
+
+            rows = Math.ceil(data.length / columns);
+
+
+            var tileWidth = Math.floor((width - (columns + 1) * tileGap) / columns);
+            var tileHeight = Math.floor((height - (rows + 1) * tileGap) / rows);
 
             var area = d3.select($("#" + id).get(0))
                 .selectAll('.area')
@@ -120,38 +138,39 @@ define(["jquery", "text!./scripts/style.css", "./scripts/themes", "./scripts/d3.
                 .enter()
                 .append('div')
                 .attr('class', 'circular-kpi-tile')
-                .attr('id', function(d, i) {
+                .attr('id', function (d, i) {
                     return id + '_circular-kpi-tile-' + i;
                 })
-				.attr('selected', 'no')
-                .style('width', Math.ceil(width / columns, 10) - 5 + 'px')
-                .style('height', Math.ceil(height / rows, 10) - 5 + 'px');
-			
-            data.forEach(function(d, i) {
-				if(HAS_TWO_DIMENSION) {
-					var value = d[2].qNum;
-					//For a multidim chart - calculate the color to use so we loop over the # of colors in the theme.
-					var colorIter = Math.round(d[1].qElemNumber/(layout.theme.length-2) % 1 * (layout.theme.length-2));
-					colors = [layout.theme[colorIter], layout.theme[colorIter+1], layout.theme[colorIter+2]];
-				}
-				else {
-					var value = HAS_DIMENSION ? d[1].qNum : d[0].qNum;
+                .attr('selected', 'no')
+                .style('width', tileWidth + 'px')
+                .style('height', tileHeight + 'px')
+                .style('margin', tileGap / 2 + 'px');
+
+            data.forEach(function (d, i) {
+                if (HAS_TWO_DIMENSION) {
+                    var value = d[2].qNum;
+                    //For a multidim chart - calculate the color to use so we loop over the # of colors in the theme.
+                    var colorIter = Math.round(d[1].qElemNumber / (layout.theme.length - 2) % 1 * (layout.theme.length - 2));
+                    colors = [layout.theme[colorIter], layout.theme[colorIter + 1], layout.theme[colorIter + 2]];
                 }
-				if(layout.singlekpilabel.length>0) {var label = HAS_DIMENSION ? d[0].qText : layout.singlekpilabel};
-				if(layout.singlekpilabel.length==0) {var label = HAS_DIMENSION ? d[0].qText : label};
-				
-				var extraLabel = HAS_TWO_DIMENSION ? d[1].qText : "";
+                else {
+                    var value = HAS_DIMENSION ? d[1].qNum : d[0].qNum;
+                }
+                if (layout.singlekpilabel.length > 0) { var label = HAS_DIMENSION ? d[0].qText : layout.singlekpilabel };
+                if (layout.singlekpilabel.length == 0) { var label = HAS_DIMENSION ? d[0].qText : label };
+
+                var extraLabel = HAS_TWO_DIMENSION ? d[1].qText : "";
 
                 var element = document.getElementById(id + '_circular-kpi-tile-' + i);
-				
+
                 var width = element.offsetWidth - 5, height = element.offsetHeight - 5;
-				
-                var select = function() {
-					$('#' + id + '_circular-kpi-tile-' + i).attr('selected', '1');
-					toggleOpacity();
+
+                var select = function () {
+                    $('#' + id + '_circular-kpi-tile-' + i).attr('selected', '1');
+                    toggleOpacity();
                     return HAS_DIMENSION ? this.selectValues(0, [d[0].qElemNumber], true) : false;
                 }.bind(this);
-                
+
                 if (width < height) {
                     height = width;
                 } else {
@@ -161,18 +180,18 @@ define(["jquery", "text!./scripts/style.css", "./scripts/themes", "./scripts/d3.
                 radialProgress(element, width, height, colors, animationTime, showdecimals, showpercentage)
                     .diameter(width)
                     .label(label)
-					.extraLabel(extraLabel)
+                    .extraLabel(extraLabel)
                     .onClick(select)
                     .value(value * 100)
                     .render();
-					
+
             }.bind(this));
-            
+
             function toggleOpacity() {
-				$("#" +id).find("[selected=no]")
-					.css({ opacity: 0.5 });
-				$("#" +id).find("[selected=selected]")
-					.css({ opacity: 1 });	
+                $("#" + id).find("[selected=no]")
+                    .css({ opacity: 0.5 });
+                $("#" + id).find("[selected=selected]")
+                    .css({ opacity: 1 });
             };
 
 

--- a/CircularKPI.qext
+++ b/CircularKPI.qext
@@ -3,7 +3,7 @@
 	"description": "Circular KPI Visualization",
 	"icon": "kpi",
 	"type": "visualization",
-	"version": "1.0.0",
+	"version": "1.2.0",
 	"author": "",
 	"homepage": "",
 	"keywords": "qlik-sense, visualization",


### PR DESCRIPTION
## Summary
Adds support for arranging KPIs based on aspect ratio to improve layout consistency across different container sizes.

## What changed
- Introduced aspect-ratio–aware arrangement logic
- Updated layout calculation to account for width/height differences

## Why
This improves visual consistency when KPIs are rendered in non-square or responsive layouts.

## Testing
- Verified rendering with multiple aspect ratios
- Confirmed no regression in default layout behavior
